### PR TITLE
feat: add HACS build workflow

### DIFF
--- a/.github/workflows/hacs-build.yml
+++ b/.github/workflows/hacs-build.yml
@@ -1,0 +1,28 @@
+name: Build HACS Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create HACS zip
+        run: zip -r ha-mqtt_sensors.zip custom_components/ha_mqtt_sensors
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hacs-build
+          path: ha-mqtt_sensors.zip
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ha-mqtt_sensors.zip


### PR DESCRIPTION
## Summary
- add workflow to package custom component for HACS and attach to releases
- update artifact upload action to v4

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe360384c832eb0926c7272b3db26