### PR TITLE
Expose config flow for GUI setup

### DIFF
--- a/.github/workflows/hacs-build.yml
+++ b/.github/workflows/hacs-build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -26,3 +28,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ha-mqtt_sensors.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/custom_components/ha_mqtt_sensors/manifest.json
+++ b/custom_components/ha_mqtt_sensors/manifest.json
@@ -1,10 +1,11 @@
 {
   "domain": "ha_mqtt_sensors",
   "name": "HA MQTT Sensors",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "documentation": "https://github.com/dfiore1230/ha-mqtt_sensors",
   "issue_tracker": "https://github.com/dfiore1230/ha-mqtt_sensors/issues",
   "codeowners": ["@dfiore1230"],
+  "config_flow": true,
   "dependencies": ["mqtt"],
   "iot_class": "local_push",
   "requirements": []

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,7 @@
+import json
+from pathlib import Path
+
+def test_config_flow_enabled():
+    manifest_path = Path(__file__).resolve().parents[1] / 'custom_components' / 'ha_mqtt_sensors' / 'manifest.json'
+    data = json.loads(manifest_path.read_text())
+    assert data.get('config_flow') is True


### PR DESCRIPTION
## Summary
- enable UI configuration by adding `config_flow` flag in manifest
- test that manifest exposes `config_flow`
- fix release workflow by granting write permission and passing `GITHUB_TOKEN`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe6c44d24832ea0b84eb57e27c819