### PR TITLE
Ensure availability tick executes on Home Assistant event loop

### DIFF
--- a/custom_components/ha_mqtt_sensors/__init__.py
+++ b/custom_components/ha_mqtt_sensors/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from datetime import datetime, timedelta
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components import mqtt
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -69,7 +69,9 @@ class MqttHub:
             self._unsub_timer()
             self._unsub_timer = None
 
+    @callback
     def _availability_tick(self, _now) -> None:
+        """Periodic callback to update availability state."""
         async_dispatcher_send(self.hass, self._signal_name(SUFFIX_AVAILABILITY), "tick")
 
     def _signal_name(self, suffix: str) -> str:


### PR DESCRIPTION
## Summary
- Mark `_availability_tick` as a Home Assistant callback so it executes on the event loop
- Avoid `async_dispatcher_send` being invoked from a worker thread

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fefcb0fec832eaef88638409af9de