### PR TITLE
Await MQTT subscription in MqttHub

### DIFF
--- a/custom_components/ha_mqtt_sensors/__init__.py
+++ b/custom_components/ha_mqtt_sensors/__init__.py
@@ -56,7 +56,7 @@ class MqttHub:
             async_dispatcher_send(self.hass, self._signal_name(suffix), payload)
             async_dispatcher_send(self.hass, self._signal_name(SUFFIX_AVAILABILITY), "tick")
 
-        self._unsub_mqtt = mqtt.async_subscribe(self.hass, topic, _cb, qos=0, encoding=None)
+        self._unsub_mqtt = await mqtt.async_subscribe(self.hass, topic, _cb, qos=0, encoding=None)
         self._unsub_timer = async_track_time_interval(
             self.hass, self._availability_tick, timedelta(seconds=30)
         )


### PR DESCRIPTION
## Summary
- Await MQTT subscriptions during hub setup
- Ensure subscriptions are cleaned up on unload

## Testing
- `python - <<'PY' ...` (simulated MQTT messages update cached states and unsubscribe on unload)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff5ebcfbc832eb0ee7b0083491581