### PR TITLE
feat: allow overriding topic prefix via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mosquitto_sub -h <BROKER_IP> -t 'sensors_345/702442/#' -v
 ```
 
 ## Options
-- Change device type and availability window from the integration’s **Options**
+- Change topic prefix, device type, and availability window from the integration’s **Options**
 
 ## Notes
 - Requires the **MQTT** integration configured in Home Assistant

--- a/custom_components/ha_mqtt_sensors/__init__.py
+++ b/custom_components/ha_mqtt_sensors/__init__.py
@@ -36,7 +36,7 @@ class MqttHub:
         self.hass = hass
         self.entry = entry
         self.sensor_id: str = entry.data[CONF_SENSOR_ID]
-        self.prefix: str = entry.data.get(CONF_PREFIX, DEFAULT_PREFIX)
+        self.prefix: str = entry.options.get(CONF_PREFIX) or entry.data.get(CONF_PREFIX, DEFAULT_PREFIX)
         self._base = f"{self.prefix}/{self.sensor_id}"
         self.states: dict[str, str | None] = {}
         self._unsub_mqtt = None

--- a/custom_components/ha_mqtt_sensors/config_flow.py
+++ b/custom_components/ha_mqtt_sensors/config_flow.py
@@ -26,6 +26,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_PREFIX: user_input.get(CONF_PREFIX, DEFAULT_PREFIX),
                 },
                 options={
+                    CONF_PREFIX: user_input.get(CONF_PREFIX, DEFAULT_PREFIX),
                     CONF_DEVICE_TYPE: user_input.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE),
                     CONF_AVAIL_MINUTES: user_input.get(CONF_AVAIL_MINUTES, DEFAULT_AVAIL_MINUTES),
                 },
@@ -52,8 +53,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        current = {**self.entry.options}
+        current = {**self.entry.data, **self.entry.options}
         schema = vol.Schema({
+            vol.Optional(CONF_PREFIX, default=current.get(CONF_PREFIX, DEFAULT_PREFIX)): str,
             vol.Optional(CONF_DEVICE_TYPE, default=current.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)): vol.In(DEVICE_CHOICES),
             vol.Optional(CONF_AVAIL_MINUTES, default=current.get(CONF_AVAIL_MINUTES, DEFAULT_AVAIL_MINUTES)): vol.All(int, vol.Range(min=1, max=1440)),
         })

--- a/custom_components/ha_mqtt_sensors/strings.json
+++ b/custom_components/ha_mqtt_sensors/strings.json
@@ -19,8 +19,9 @@
     "step": {
       "init": {
         "title": "HA MQTT Sensors Options",
-        "description": "Adjust device type and availability window",
+        "description": "Adjust topic prefix, device type, and availability window",
         "data": {
+          "topic_prefix": "Topic prefix",
           "device_type": "Device type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)"
         }

--- a/custom_components/ha_mqtt_sensors/translations/en.json
+++ b/custom_components/ha_mqtt_sensors/translations/en.json
@@ -19,8 +19,9 @@
     "step": {
       "init": {
         "title": "HA MQTT Sensors Options",
-        "description": "Adjust device type and availability window",
+        "description": "Adjust topic prefix, device type, and availability window",
         "data": {
+          "topic_prefix": "Topic prefix",
           "device_type": "Device type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)"
         }

--- a/tests/test_mqtt_updates.py
+++ b/tests/test_mqtt_updates.py
@@ -195,3 +195,14 @@ def test_contact_entity_state_updates():
     callback(Msg(topic, "open"))
 
     assert entity.is_on is True
+
+
+def test_hub_uses_prefix_from_options():
+    hass = HomeAssistant()
+    entry = ConfigEntry(
+        data={CONF_SENSOR_ID: "abc123", CONF_PREFIX: "data_prefix"},
+        options={CONF_PREFIX: "opt_prefix"},
+        entry_id="entry2",
+    )
+    hub = MqttHub(hass, entry)
+    assert hub.base_topic == "opt_prefix/abc123"


### PR DESCRIPTION
## Summary
- allow topic prefix to be configured from options flow
- prefer prefix in entry options when building MQTT topics
- document changing topic prefix via integration options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ffdd4a508832e9078f2f245b35aad