### PR TITLE
Restore last known states for MQTT sensors

### DIFF
--- a/tests/test_mqtt_updates.py
+++ b/tests/test_mqtt_updates.py
@@ -9,6 +9,10 @@ from datetime import datetime
 # Ensure the repository root is on sys.path for imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 # core module
+ha_pkg = types.ModuleType("homeassistant")
+sys.modules["homeassistant"] = ha_pkg
+helpers_pkg = types.ModuleType("homeassistant.helpers")
+sys.modules["homeassistant.helpers"] = helpers_pkg
 core = types.ModuleType("homeassistant.core")
 
 class _Loop:
@@ -106,6 +110,26 @@ entity_helper.DeviceInfo = DeviceInfo
 entity_helper.EntityCategory = EntityCategory
 sys.modules["homeassistant.helpers.entity"] = entity_helper
 
+# helpers.restore_state module
+restore_state = types.ModuleType("homeassistant.helpers.restore_state")
+
+class State:
+    def __init__(self, state):
+        self.state = state
+
+restore_state.State = State
+restore_state.last_states = {}
+
+class RestoreEntity:
+    async def async_added_to_hass(self):
+        pass
+
+    async def async_get_last_state(self):
+        return restore_state.last_states.get(getattr(self, "entity_id", None))
+
+restore_state.RestoreEntity = RestoreEntity
+sys.modules["homeassistant.helpers.restore_state"] = restore_state
+
 # components.binary_sensor module
 bin_sensor = types.ModuleType("homeassistant.components.binary_sensor")
 
@@ -137,6 +161,31 @@ bin_sensor.BinarySensorDeviceClass = BinarySensorDeviceClass
 bin_sensor.BinarySensorEntity = BinarySensorEntity
 sys.modules["homeassistant.components.binary_sensor"] = bin_sensor
 
+# components.sensor module
+sensor_mod = types.ModuleType("homeassistant.components.sensor")
+
+class SensorDeviceClass:
+    TIMESTAMP = "timestamp"
+
+
+class SensorEntity:
+    def __init__(self):
+        self.hass = None
+
+    async def async_added_to_hass(self):
+        pass
+
+    async def async_will_remove_from_hass(self):
+        pass
+
+    def async_write_ha_state(self):
+        pass
+
+
+sensor_mod.SensorDeviceClass = SensorDeviceClass
+sensor_mod.SensorEntity = SensorEntity
+sys.modules["homeassistant.components.sensor"] = sensor_mod
+
 # util.dt module
 util = types.ModuleType("homeassistant.util")
 sys.modules["homeassistant.util"] = util
@@ -146,6 +195,20 @@ def utcnow():
     return datetime.utcnow()
 
 dt.utcnow = utcnow
+def get_time_zone(_zone):
+    class _TZ:
+        def localize(self, dt_obj):
+            return dt_obj
+    return _TZ()
+
+def parse_datetime(val):
+    try:
+        return datetime.fromisoformat(val)
+    except Exception:
+        return None
+
+dt.get_time_zone = get_time_zone
+dt.parse_datetime = parse_datetime
 sys.modules["homeassistant.util.dt"] = dt
 # ---- End stubs for homeassistant ----
 
@@ -158,11 +221,13 @@ from custom_components.ha_mqtt_sensors.const import (
     DEFAULT_PREFIX,
 )
 from custom_components.ha_mqtt_sensors.binary_sensor import ContactEntity
+from custom_components.ha_mqtt_sensors.sensor import IntTopicSensor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.mqtt import subscriptions
+import homeassistant.helpers.restore_state as restore_state
 
 import pytest
 
@@ -195,3 +260,43 @@ def test_contact_entity_state_updates():
     callback(Msg(topic, "open"))
 
     assert entity.is_on is True
+
+
+def test_contact_entity_restores_state():
+    sensor_id = "abc123"
+    hass = HomeAssistant()
+    entry = ConfigEntry(
+        data={CONF_SENSOR_ID: sensor_id, CONF_NAME: "Test", CONF_PREFIX: DEFAULT_PREFIX},
+        options={},
+        entry_id="entry1",
+    )
+    hub = MqttHub(hass, entry)
+    asyncio.run(hub.async_setup())
+
+    entity = ContactEntity(hub, entry, DeviceInfo(), "Test Door", BinarySensorDeviceClass.DOOR)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.test_door"
+    restore_state.last_states[entity.entity_id] = restore_state.State("on")
+    asyncio.run(entity.async_added_to_hass())
+
+    assert entity.is_on is True
+
+
+def test_int_sensor_restores_state():
+    sensor_id = "abc123"
+    hass = HomeAssistant()
+    entry = ConfigEntry(
+        data={CONF_SENSOR_ID: sensor_id, CONF_NAME: "Test", CONF_PREFIX: DEFAULT_PREFIX},
+        options={},
+        entry_id="entry1",
+    )
+    hub = MqttHub(hass, entry)
+    asyncio.run(hub.async_setup())
+
+    entity = IntTopicSensor(hub, entry, DeviceInfo(), "Test Event", "event")
+    entity.hass = hass
+    entity.entity_id = "sensor.test_event"
+    restore_state.last_states[entity.entity_id] = restore_state.State("5")
+    asyncio.run(entity.async_added_to_hass())
+
+    assert entity.native_value == 5


### PR DESCRIPTION
## Summary
- inherit RestoreEntity in base sensor classes
- load last persisted states before subscribing to MQTT
- test state restoration across restarts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ffde39554832e88b4e240ff8be63b