### PR TITLE
Add heartbeat sensor entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home Assistant custom integration that creates a device with multiple entities f
 ## Features
 - Device type selection per sensor: **door**, **window**, **leak**
 - Binary sensors: Contact, Tamper, Battery Low, Alarm, Connectivity
-- Sensors: Last Seen (timestamp), Event, Channel, State (text), MIC, ID
+- Sensors: Last Seen (timestamp), Event, Channel, Heartbeat, State (text), MIC, ID
 - Availability/Connectivity turns **on** when a message was seen within N minutes (default 5)
 
 ## Install
@@ -41,6 +41,7 @@ Home Assistant custom integration that creates a device with multiple entities f
 - **Tamper**: `tamper` == 1 → **on**
 - **Alarm**: `alarm` == 1 → **on**
 - **Connectivity**: last message within N minutes → **on** (configurable)
+- **Heartbeat**: `heartbeat` integer (e.g., 0 or 1)
 
 ## Mosquitto quick check
 ```bash

--- a/custom_components/ha_mqtt_sensors/sensor.py
+++ b/custom_components/ha_mqtt_sensors/sensor.py
@@ -8,7 +8,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import dt as dt_util
 from .const import (
     DOMAIN, CONF_SENSOR_ID, CONF_NAME,
-    TOPIC_TIME, TOPIC_EVENT, TOPIC_CHANNEL, TOPIC_STATE, TOPIC_MIC, TOPIC_ID
+    TOPIC_TIME, TOPIC_EVENT, TOPIC_CHANNEL, TOPIC_HEARTBEAT,
+    TOPIC_STATE, TOPIC_MIC, TOPIC_ID,
 )
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
@@ -25,11 +26,12 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
 
     entities = [
         LastSeenSensor(hub, entry, dev_info, f"{base_name} Last Seen"),
-        IntTopicSensor(hub, entry, dev_info, f"{base_name} Event", "event"),
-        IntTopicSensor(hub, entry, dev_info, f"{base_name} Channel", "channel"),
-        TextTopicSensor(hub, entry, dev_info, f"{base_name} State Text", "state"),
-        TextTopicSensor(hub, entry, dev_info, f"{base_name} MIC", "mic"),
-        TextTopicSensor(hub, entry, dev_info, f"{base_name} ID", "id"),
+        IntTopicSensor(hub, entry, dev_info, f"{base_name} Event", TOPIC_EVENT),
+        IntTopicSensor(hub, entry, dev_info, f"{base_name} Channel", TOPIC_CHANNEL),
+        IntTopicSensor(hub, entry, dev_info, f"{base_name} Heartbeat", TOPIC_HEARTBEAT),
+        TextTopicSensor(hub, entry, dev_info, f"{base_name} State Text", TOPIC_STATE),
+        TextTopicSensor(hub, entry, dev_info, f"{base_name} MIC", TOPIC_MIC),
+        TextTopicSensor(hub, entry, dev_info, f"{base_name} ID", TOPIC_ID),
     ]
     async_add_entities(entities)
 


### PR DESCRIPTION
## Summary
- expose MQTT heartbeat as integer sensor
- document heartbeat entity and payload in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ffdeae2f0832eb07c048b18dab71f