### PR TITLE
Use combined prefix and sensor ID for unique identifiers

### DIFF
--- a/custom_components/ha_mqtt_sensors/__init__.py
+++ b/custom_components/ha_mqtt_sensors/__init__.py
@@ -37,6 +37,7 @@ class MqttHub:
         self.entry = entry
         self.sensor_id: str = entry.data[CONF_SENSOR_ID]
         self.prefix: str = entry.options.get(CONF_PREFIX) or entry.data.get(CONF_PREFIX, DEFAULT_PREFIX)
+        self.combined_id: str = f"{self.prefix}_{self.sensor_id}"
         self._base = f"{self.prefix}/{self.sensor_id}"
         self.states: dict[str, str | None] = {}
         self._unsub_mqtt = None

--- a/custom_components/ha_mqtt_sensors/binary_sensor.py
+++ b/custom_components/ha_mqtt_sensors/binary_sensor.py
@@ -9,18 +9,17 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    DOMAIN, CONF_SENSOR_ID, CONF_NAME,
+    DOMAIN, CONF_NAME,
     TOPIC_CONTACT, TOPIC_REED, TOPIC_STATE, TOPIC_TAMPER, TOPIC_BATTOK, TOPIC_ALARM,
     SUFFIX_AVAILABILITY, CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE, CONF_AVAIL_MINUTES, DEFAULT_AVAIL_MINUTES
 )
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
     hub = hass.data[DOMAIN][entry.entry_id]
-    sensor_id = entry.data[CONF_SENSOR_ID]
     base_name = entry.data[CONF_NAME]
 
     dev_info = DeviceInfo(
-        identifiers={(DOMAIN, sensor_id)},
+        identifiers={(DOMAIN, hub.combined_id)},
         name=base_name,
         manufacturer="345MHz Receiver",
         model="Honeywell/345 Contact",
@@ -53,7 +52,7 @@ class _BaseBin(RestoreEntity, BinarySensorEntity):
         self._hub = hub
         self._entry = entry
         self._attr_name = name
-        self._attr_unique_id = f"{hub.sensor_id}_{unique_suffix}"
+        self._attr_unique_id = f"{hub.combined_id}_{unique_suffix}"
         self._attr_device_info = dev_info
         self._removers = []
 

--- a/custom_components/ha_mqtt_sensors/sensor.py
+++ b/custom_components/ha_mqtt_sensors/sensor.py
@@ -8,18 +8,17 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 from .const import (
-    DOMAIN, CONF_SENSOR_ID, CONF_NAME,
+    DOMAIN, CONF_NAME,
     TOPIC_TIME, TOPIC_EVENT, TOPIC_CHANNEL, TOPIC_HEARTBEAT,
     TOPIC_STATE, TOPIC_MIC, TOPIC_ID,
 )
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
     hub = hass.data[DOMAIN][entry.entry_id]
-    sensor_id = entry.data[CONF_SENSOR_ID]
     base_name = entry.data[CONF_NAME]
 
     dev_info = DeviceInfo(
-        identifiers={(DOMAIN, sensor_id)},
+        identifiers={(DOMAIN, hub.combined_id)},
         name=base_name,
         manufacturer="345MHz Receiver",
         model="Honeywell/345 Contact",
@@ -43,7 +42,7 @@ class _BaseSensor(RestoreEntity, SensorEntity):
         self._hub = hub
         self._entry = entry
         self._attr_name = name
-        self._attr_unique_id = f"{hub.sensor_id}_{unique_suffix}"
+        self._attr_unique_id = f"{hub.combined_id}_{unique_suffix}"
         self._attr_device_info = dev_info
         self._remove = None
 


### PR DESCRIPTION
## Summary
- Build a combined ID from MQTT prefix and sensor ID
- Use combined ID for device identifiers and unique IDs

## Testing
- `pytest tests/test_mqtt_updates.py`
- `pre-commit run --files custom_components/ha_mqtt_sensors/__init__.py custom_components/ha_mqtt_sensors/binary_sensor.py custom_components/ha_mqtt_sensors/sensor.py tests/test_mqtt_updates.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a000af7aa0832ea1644db85a74620d