### PR TITLE
Clamp LastSeenSensor future timestamps

### DIFF
--- a/custom_components/ha_mqtt_sensors/sensor.py
+++ b/custom_components/ha_mqtt_sensors/sensor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from datetime import datetime
+from datetime import datetime, timedelta
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.config_entries import ConfigEntry
@@ -72,7 +72,13 @@ class LastSeenSensor(_BaseSensor):
     @property
     def native_value(self):
         val = self._hub.states.get(TOPIC_TIME)
-        return parse_datetime_utc(self.hass, val)
+        parsed = parse_datetime_utc(self.hass, val)
+        if parsed is None:
+            return None
+        now = dt_util.as_utc(dt_util.utcnow())
+        if parsed - now > timedelta(seconds=1):
+            return now
+        return parsed
 
 class IntTopicSensor(_BaseSensor):
     def __init__(self, hub, entry, dev_info, name, topic_suffix: str):

--- a/tests/test_sensor_time_parsing.py
+++ b/tests/test_sensor_time_parsing.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from custom_components.ha_mqtt_sensors.sensor import LastSeenSensor
 from custom_components.ha_mqtt_sensors.const import TOPIC_TIME
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.util import dt as dt_util
 
 
 def _make_sensor(hass, hub):
@@ -33,3 +34,12 @@ def test_dst_nonexistent_time_returns_none(hass, stub_hub):
     hub.states[TOPIC_TIME] = "2023-03-12 02:30:00"
     sensor = _make_sensor(hass, hub)
     assert sensor.native_value is None
+
+
+def test_future_timestamp_returns_now(hass, stub_hub):
+    hub = stub_hub
+    future = dt_util.utcnow() + timedelta(hours=1)
+    hub.states[TOPIC_TIME] = future.isoformat()
+    sensor = _make_sensor(hass, hub)
+    value = sensor.native_value
+    assert value <= dt_util.as_utc(dt_util.utcnow())


### PR DESCRIPTION
## Summary
- ensure LastSeenSensor never reports times in the future by clamping values past the current UTC time
- test time parsing to handle future timestamps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2047321e0832e9eb4a46715b355e2