### PR TITLE
Add GUI option to change sensor type

### DIFF
--- a/custom_components/ha_mqtt_sensors/__init__.py
+++ b/custom_components/ha_mqtt_sensors/__init__.py
@@ -21,6 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hub = MqttHub(hass, entry)
     await hub.async_setup()
     hass.data[DOMAIN][entry.entry_id] = hub
+    entry.async_on_unload(entry.add_update_listener(_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -30,6 +31,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await hass.data[DOMAIN][entry.entry_id].async_unload()
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unloaded
+
+
+async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle config entry updates by reloading entry."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 class MqttHub:
     """Subscribe to <prefix>/<id>/+ and cache latest values; track availability."""

--- a/custom_components/ha_mqtt_sensors/strings.json
+++ b/custom_components/ha_mqtt_sensors/strings.json
@@ -9,7 +9,7 @@
           "sensor_id": "Sensor ID",
           "name": "Name",
           "topic_prefix": "Topic prefix",
-          "device_type": "Device type (door/window/leak)",
+          "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)"
         }
       }
@@ -19,10 +19,10 @@
     "step": {
       "init": {
         "title": "HA MQTT Sensors Options",
-        "description": "Adjust topic prefix, device type, and availability window",
+        "description": "Adjust topic prefix, sensor type, and availability window",
         "data": {
           "topic_prefix": "Topic prefix",
-          "device_type": "Device type (door/window/leak)",
+          "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)"
         }
       }

--- a/custom_components/ha_mqtt_sensors/translations/en.json
+++ b/custom_components/ha_mqtt_sensors/translations/en.json
@@ -9,7 +9,7 @@
           "sensor_id": "Sensor ID",
           "name": "Name",
           "topic_prefix": "Topic prefix",
-          "device_type": "Device type (door/window/leak)",
+          "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)"
         }
       }
@@ -19,10 +19,10 @@
     "step": {
       "init": {
         "title": "HA MQTT Sensors Options",
-        "description": "Adjust topic prefix, device type, and availability window",
+        "description": "Adjust topic prefix, sensor type, and availability window",
         "data": {
           "topic_prefix": "Topic prefix",
-          "device_type": "Device type (door/window/leak)",
+          "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)"
         }
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,8 +44,64 @@ class ConfigEntry:
     options: dict
     entry_id: str = "1"
 
+class ConfigFlow:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+class OptionsFlow:
+    def async_show_form(self, step_id, data_schema):
+        return {"type": "form", "step_id": step_id, "data_schema": data_schema}
+
+    def async_create_entry(self, title, data):
+        return {"type": "create_entry", "title": title, "data": data}
+
 config_entries.ConfigEntry = ConfigEntry
+config_entries.ConfigFlow = ConfigFlow
+config_entries.OptionsFlow = OptionsFlow
 sys.modules["homeassistant.config_entries"] = config_entries
+
+# voluptuous module (schema validation) stub
+vol = types.ModuleType("voluptuous")
+
+class Schema:
+    def __init__(self, schema):
+        self.schema = schema
+    def __call__(self, data):
+        return data
+
+def Optional(key, default=None, description=None):
+    return key
+
+def Required(key, description=None):
+    return key
+
+def In(values):
+    def _validator(value):
+        return value
+    return _validator
+
+def All(*args, **kwargs):
+    def _validator(value):
+        return value
+    return _validator
+
+def Range(min=None, max=None):
+    def _validator(value):
+        return value
+    return _validator
+
+vol.Schema = Schema
+vol.Optional = Optional
+vol.Required = Required
+vol.In = In
+vol.All = All
+vol.Range = Range
+sys.modules["voluptuous"] = vol
+
+# data_entry_flow module
+data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
+data_entry_flow.FlowResult = dict
+sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
 
 # helpers.entity module
 entity_helper = types.ModuleType("homeassistant.helpers.entity")

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from custom_components.ha_mqtt_sensors import config_flow
+from custom_components.ha_mqtt_sensors.const import CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE
+from homeassistant.config_entries import ConfigEntry
+
+
+def test_options_flow_changes_device_type():
+    entry = ConfigEntry(data={}, options={CONF_DEVICE_TYPE: DEFAULT_DEVICE_TYPE})
+    handler = config_flow.OptionsFlowHandler(entry)
+
+    result = asyncio.run(handler.async_step_init())
+    assert result["type"] == "form"
+    assert CONF_DEVICE_TYPE in result["data_schema"].schema
+
+    result2 = asyncio.run(handler.async_step_init({CONF_DEVICE_TYPE: "door"}))
+    assert result2["type"] == "create_entry"
+    assert result2["data"][CONF_DEVICE_TYPE] == "door"


### PR DESCRIPTION
## Summary
- allow changing sensor type via options GUI
- reload entry when options change
- add tests for options flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a206cb6188832e89eb3765bc950245