### PR TITLE
Ensure sensor states restore across restarts

### DIFF
--- a/custom_components/ha_mqtt_sensors/sensor.py
+++ b/custom_components/ha_mqtt_sensors/sensor.py
@@ -63,6 +63,9 @@ class LastSeenSensor(_BaseSensor):
         last = await self.async_get_last_state()
         if last and last.state != "unknown":
             self._hub.states[TOPIC_TIME] = last.state
+            parsed = parse_datetime_utc(self.hass, last.state)
+            if parsed is not None:
+                self._hub._last_seen_utc = parsed
         @callback
         def _on(_payload: str):
             self.async_write_ha_state()


### PR DESCRIPTION
## Summary
- Default contact sensors to a closed state when no previous state exists
- Restore hub's last seen timestamp so availability persists across restarts
- Adjust state logic and tests for restored/default behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32878b9a0832e8f7f6d5f152baabf