### PR TITLE
Support additional DW10 event codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Home Assistant custom integration that creates a device with multiple entities f
 ```
 
 ## Entity mapping
-- **Contact**: `event` 160=open / 128=closed, else `contact_open` → 1=open, else `reed_open` → 1=open, else `state` text `open/closed/wet/dry`
+- **Contact**: `event` 160/168/192/200/232 = open or 128/40/64/104 = closed, else `contact_open` → 1=open, else `reed_open` → 1=open, else `state` text `open/closed/wet/dry`
 - **Battery Low**: `battery_ok` == 0 → **on**
 - **Tamper**: `tamper` == 1 → **on**
 - **Alarm**: `alarm` == 1 → **on**

--- a/custom_components/ha_mqtt_sensors/const.py
+++ b/custom_components/ha_mqtt_sensors/const.py
@@ -40,5 +40,8 @@ CONTACT_OPEN_STATES = {"open", "opened", "wet", "leak"}
 CONTACT_CLOSED_STATES = {"close", "closed", "dry"}
 
 # Event codes for contact sensors
-CONTACT_OPEN_EVENTS = {160}
-CONTACT_CLOSED_EVENTS = {128}
+# Different firmware/conditions may report a variety of values while still
+# indicating a simple open/closed state.  Include the known variants so the
+# contact entity can normalize them.
+CONTACT_OPEN_EVENTS = {160, 168, 192, 200, 232}
+CONTACT_CLOSED_EVENTS = {128, 40, 64, 104}

--- a/tests/test_mqtt_updates.py
+++ b/tests/test_mqtt_updates.py
@@ -71,10 +71,12 @@ def test_contact_entity_event_updates(hass):
             self.topic = topic
             self.payload = payload
 
-    callback(Msg(topic, "160"))
-    assert entity.is_on is True
-    callback(Msg(topic, "128"))
-    assert entity.is_on is False
+    for code in (160, 168, 192, 200, 232):
+        callback(Msg(topic, str(code)))
+        assert entity.is_on is True
+    for code in (128, 40, 64, 104):
+        callback(Msg(topic, str(code)))
+        assert entity.is_on is False
 
 
 def test_contact_ignores_topics_by_default(hass):


### PR DESCRIPTION
## Summary
- handle DW10 345MHz sensor variants that report additional event codes
- document and test extra event codes for open/closed contact states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49127da4c832eb53d202b9fa80e8a