### PR TITLE
Support zoneinfo timezones and update utcnow stub

### DIFF
--- a/custom_components/ha_mqtt_sensors/util.py
+++ b/custom_components/ha_mqtt_sensors/util.py
@@ -23,10 +23,14 @@ def parse_datetime_utc(hass, val: str):
         dt_local = datetime.strptime(val, "%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return None
-    tz = dt_util.get_time_zone(getattr(getattr(hass, "config", None), "time_zone", None) or "UTC")
+    tz_name = getattr(getattr(hass, "config", None), "time_zone", None) or "UTC"
+    tz = dt_util.get_time_zone(tz_name)
     if tz is not None:
         try:
-            dt_local = tz.localize(dt_local)
+            if hasattr(tz, "localize"):
+                dt_local = tz.localize(dt_local)
+            else:
+                dt_local = dt_local.replace(tzinfo=tz)
         except Exception:
             return None
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,7 +243,7 @@ sys.modules["homeassistant.util"] = util_pkg
 dt = types.ModuleType("homeassistant.util.dt")
 
 def utcnow():
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 def get_time_zone(name):
     class TZ:

--- a/tests/test_sensor_time_parsing.py
+++ b/tests/test_sensor_time_parsing.py
@@ -43,3 +43,11 @@ def test_future_timestamp_returns_now(hass, stub_hub):
     sensor = _make_sensor(hass, hub)
     value = sensor.native_value
     assert value <= dt_util.as_utc(dt_util.utcnow())
+
+
+def test_zoneinfo_timezone_parsed(hass, stub_hub, monkeypatch):
+    hub = stub_hub
+    hub.states[TOPIC_TIME] = "2023-03-10 12:34:56"
+    monkeypatch.setattr(dt_util, "get_time_zone", lambda name: timezone.utc)
+    sensor = _make_sensor(hass, hub)
+    assert sensor.native_value == datetime(2023, 3, 10, 12, 34, 56, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- allow `parse_datetime_utc` to handle zoneinfo timezones without a `localize` method
- replace deprecated `datetime.utcnow()` usage in test stubs with `datetime.now(timezone.utc)`
- add regression test for zoneinfo timezone parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4bdf80a24832e8eb7d89df5b732b6