### PR TITLE
Add availability tick option and improve logging/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home Assistant custom integration that creates a device with multiple entities f
 ## Features
 - Device type selection per sensor: **door**, **window**, **leak**
 - Binary sensors: Contact, Tamper, Battery Low, Alarm, Connectivity
-- Sensors: Last Seen (timestamp), Event, Channel, Heartbeat, State (text), MIC, ID
+- Sensors: Last Seen (timestamp), Event, Channel, Heartbeat, State (text), MIC, ID, Signal Strength
 - Availability/Connectivity turns **on** when a message was seen within N minutes (default 30)
 
 ## MQTT Setup
@@ -61,6 +61,7 @@ Home Assistant custom integration that creates a device with multiple entities f
 <prefix>/<id>/battery_ok    e.g. 1
 <prefix>/<id>/heartbeat     e.g. 0
 <prefix>/<id>/mic           e.g. CRC
+<prefix>/<id>/rssi          e.g. -42
 ```
 
 ## Entity mapping
@@ -86,7 +87,6 @@ The integration exposes several options via the Home Assistant UI:
 | Topic Prefix | MQTT topic prefix |
 | Sensor Type | Device type for sensor (door/window/leak) |
 | Availability Window | Minutes until the device is considered offline |
-| Use External Sensor | Use external contact sensor for state |
-| Use Internal Sensor | Use internal reed sensor for state |
+| Availability Tick Interval | Seconds between availability updates |
+| Sensor Source | Source for contact state (external/internal) |
 
-Only one of **Use External Sensor** or **Use Internal Sensor** can be enabled at a time.

--- a/custom_components/ha_mqtt_sensors/__init__.py
+++ b/custom_components/ha_mqtt_sensors/__init__.py
@@ -9,8 +9,15 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    DOMAIN, PLATFORMS, CONF_SENSOR_ID, CONF_PREFIX, DEFAULT_PREFIX, SIG_UPDATE,
-    SUFFIX_AVAILABILITY
+    DOMAIN,
+    PLATFORMS,
+    CONF_SENSOR_ID,
+    CONF_PREFIX,
+    DEFAULT_PREFIX,
+    SIG_UPDATE,
+    SUFFIX_AVAILABILITY,
+    CONF_AVAIL_TICK,
+    DEFAULT_AVAIL_TICK,
 )
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
@@ -50,6 +57,7 @@ class MqttHub:
         self._unsub_mqtt = None
         self._unsub_timer = None
         self._last_seen_utc = None  # datetime
+        self._tick_seconds = entry.options.get(CONF_AVAIL_TICK, DEFAULT_AVAIL_TICK)
 
     async def async_setup(self) -> None:
         await mqtt.async_wait_for_mqtt_client(self.hass)
@@ -83,7 +91,7 @@ class MqttHub:
 
         self._unsub_mqtt = await mqtt.async_subscribe(self.hass, topic, _cb, qos=0, encoding=None)
         self._unsub_timer = async_track_time_interval(
-            self.hass, self._availability_tick, timedelta(seconds=30)
+            self.hass, self._availability_tick, timedelta(seconds=self._tick_seconds)
         )
 
     async def async_unload(self) -> None:

--- a/custom_components/ha_mqtt_sensors/binary_sensor.py
+++ b/custom_components/ha_mqtt_sensors/binary_sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from datetime import timedelta
+import logging
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.config_entries import ConfigEntry
@@ -127,6 +128,8 @@ class ContactEntity(_BaseBin):
                 event_val = True
             elif code in CONTACT_CLOSED_EVENTS:
                 event_val = False
+            elif code is not None:
+                logging.getLogger(__name__).debug("Unknown event code %s", code)
 
         state_text = (self._hub.states.get(TOPIC_STATE) or "").lower()
         state_val = None

--- a/custom_components/ha_mqtt_sensors/config_flow.py
+++ b/custom_components/ha_mqtt_sensors/config_flow.py
@@ -13,6 +13,8 @@ from .const import (
     DEFAULT_DEVICE_TYPE,
     CONF_AVAIL_MINUTES,
     DEFAULT_AVAIL_MINUTES,
+    CONF_AVAIL_TICK,
+    DEFAULT_AVAIL_TICK,
     CONF_SENSOR_SOURCE,
     DEFAULT_SENSOR_SOURCE,
     SENSOR_SOURCE_EXTERNAL,
@@ -37,6 +39,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(
                 CONF_AVAIL_MINUTES, default=DEFAULT_AVAIL_MINUTES
             ): vol.All(int, vol.Range(min=1, max=1440)),
+            vol.Optional(
+                CONF_AVAIL_TICK, default=DEFAULT_AVAIL_TICK
+            ): vol.All(int, vol.Range(min=5, max=3600)),
             vol.Required(CONF_SENSOR_SOURCE): vol.In(
                 [SENSOR_SOURCE_EXTERNAL, SENSOR_SOURCE_INTERNAL]
             ),
@@ -62,6 +67,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                     CONF_AVAIL_MINUTES: user_input.get(
                         CONF_AVAIL_MINUTES, DEFAULT_AVAIL_MINUTES
+                    ),
+                    CONF_AVAIL_TICK: user_input.get(
+                        CONF_AVAIL_TICK, DEFAULT_AVAIL_TICK
                     ),
                     CONF_SENSOR_SOURCE: user_input[CONF_SENSOR_SOURCE],
                 },
@@ -91,6 +99,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_AVAIL_MINUTES,
                 default=current.get(CONF_AVAIL_MINUTES, DEFAULT_AVAIL_MINUTES),
             ): vol.All(int, vol.Range(min=1, max=1440)),
+            vol.Optional(
+                CONF_AVAIL_TICK,
+                default=current.get(CONF_AVAIL_TICK, DEFAULT_AVAIL_TICK),
+            ): vol.All(int, vol.Range(min=5, max=3600)),
             vol.Required(CONF_SENSOR_SOURCE): vol.In(
                 [SENSOR_SOURCE_EXTERNAL, SENSOR_SOURCE_INTERNAL]
             ),

--- a/custom_components/ha_mqtt_sensors/const.py
+++ b/custom_components/ha_mqtt_sensors/const.py
@@ -10,7 +10,9 @@ DEFAULT_PREFIX = "sensors_345"
 CONF_DEVICE_TYPE = "device_type"           # "door" | "window" | "leak"
 DEFAULT_DEVICE_TYPE = "window"
 CONF_AVAIL_MINUTES = "availability_minutes"
-DEFAULT_AVAIL_MINUTES = 90 
+DEFAULT_AVAIL_MINUTES = 90
+CONF_AVAIL_TICK = "availability_tick_seconds"
+DEFAULT_AVAIL_TICK = 30
 
 # Contact sensor source selection
 CONF_SENSOR_SOURCE = "sensor_source"  # "external" | "internal"

--- a/custom_components/ha_mqtt_sensors/strings.json
+++ b/custom_components/ha_mqtt_sensors/strings.json
@@ -1,9 +1,6 @@
 {
   "title": "HA MQTT Sensors",
   "config": {
-    "error": {
-      "one_sensor": "Select either external or internal sensor, not both"
-    },
     "step": {
       "user": {
         "title": "Add MQTT Sensor",
@@ -14,6 +11,7 @@
           "topic_prefix": "Topic prefix",
           "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)",
+          "availability_tick_seconds": "Availability tick interval (seconds)",
           "sensor_source": {
             "name": "Sensor source",
             "options": {
@@ -26,9 +24,6 @@
     }
   },
   "options": {
-    "error": {
-      "one_sensor": "Select either external or internal sensor, not both"
-    },
     "step": {
       "init": {
         "title": "HA MQTT Sensors Options",
@@ -37,6 +32,7 @@
           "topic_prefix": "Topic prefix",
           "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)",
+          "availability_tick_seconds": "Availability tick interval (seconds)",
           "sensor_source": {
             "name": "Sensor source",
             "options": {

--- a/custom_components/ha_mqtt_sensors/translations/en.json
+++ b/custom_components/ha_mqtt_sensors/translations/en.json
@@ -1,9 +1,6 @@
 {
   "title": "HA MQTT Sensors",
   "config": {
-    "error": {
-      "one_sensor": "Select either external or internal sensor, not both"
-    },
     "step": {
       "user": {
         "title": "Add MQTT Sensor",
@@ -14,6 +11,7 @@
           "topic_prefix": "Topic prefix",
           "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)",
+          "availability_tick_seconds": "Availability tick interval (seconds)",
           "sensor_source": {
             "name": "Sensor source",
             "options": {
@@ -26,9 +24,6 @@
     }
   },
   "options": {
-    "error": {
-      "one_sensor": "Select either external or internal sensor, not both"
-    },
     "step": {
       "init": {
         "title": "HA MQTT Sensors Options",
@@ -37,6 +32,7 @@
           "topic_prefix": "Topic prefix",
           "device_type": "Sensor type (door/window/leak)",
           "availability_minutes": "Availability window (minutes)",
+          "availability_tick_seconds": "Availability tick interval (seconds)",
           "sensor_source": {
             "name": "Sensor source",
             "options": {

--- a/custom_components/ha_mqtt_sensors/translations/es.json
+++ b/custom_components/ha_mqtt_sensors/translations/es.json
@@ -1,0 +1,47 @@
+{
+  "title": "HA MQTT Sensors",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Agregar sensor MQTT",
+        "description": "Ingrese el ID del sensor y los ajustes",
+        "data": {
+          "sensor_id": "ID del sensor",
+          "name": "Nombre",
+          "topic_prefix": "Prefijo del tema",
+          "device_type": "Tipo de sensor (puerta/ventana/fuga)",
+          "availability_minutes": "Ventana de disponibilidad (minutos)",
+          "availability_tick_seconds": "Intervalo de actualización de disponibilidad (segundos)",
+          "sensor_source": {
+            "name": "Fuente del sensor",
+            "options": {
+              "external": "Usar sensor externo",
+              "internal": "Usar sensor interno"
+            }
+          }
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de HA MQTT Sensors",
+        "description": "Ajuste el prefijo del tema, el tipo de sensor y la ventana de disponibilidad",
+        "data": {
+          "topic_prefix": "Prefijo del tema",
+          "device_type": "Tipo de sensor (puerta/ventana/fuga)",
+          "availability_minutes": "Ventana de disponibilidad (minutos)",
+          "availability_tick_seconds": "Intervalo de actualización de disponibilidad (segundos)",
+          "sensor_source": {
+            "name": "Fuente del sensor",
+            "options": {
+              "external": "Usar sensor externo",
+              "internal": "Usar sensor interno"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,9 +1,17 @@
 from datetime import timedelta
+import asyncio
+from unittest.mock import patch
 
+from custom_components.ha_mqtt_sensors import MqttHub
 from custom_components.ha_mqtt_sensors.binary_sensor import AvailabilityEntity
 from custom_components.ha_mqtt_sensors.const import (
     CONF_AVAIL_MINUTES,
     DEFAULT_AVAIL_MINUTES,
+    CONF_AVAIL_TICK,
+    CONF_SENSOR_ID,
+    CONF_NAME,
+    CONF_PREFIX,
+    DEFAULT_PREFIX,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import DeviceInfo
@@ -28,3 +36,15 @@ def test_availability_based_on_last_seen(hass, stub_hub):
         minutes=DEFAULT_AVAIL_MINUTES * 2
     )
     assert entity.is_on is False
+
+
+def test_configurable_availability_tick_interval(hass):
+    entry = ConfigEntry(
+        data={CONF_SENSOR_ID: "abc123", CONF_NAME: "Test", CONF_PREFIX: DEFAULT_PREFIX},
+        options={CONF_AVAIL_TICK: 10},
+        entry_id="entry1",
+    )
+    hub = MqttHub(hass, entry)
+    with patch("custom_components.ha_mqtt_sensors.async_track_time_interval") as mock_track:
+        asyncio.run(hub.async_setup())
+        assert mock_track.call_args[0][2] == timedelta(seconds=10)


### PR DESCRIPTION
## Summary
- make availability polling interval configurable
- log unknown contact event codes
- document RSSI topic and add Spanish translations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4bfb8f4ac832ea5a55bf0f8b3bb33